### PR TITLE
Update examples to reflect LE issuance changes

### DIFF
--- a/ruby/request_letsencrypt_certificate.rb
+++ b/ruby/request_letsencrypt_certificate.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Usage: ENV["CERTIFICATE_DOMAIN_ID"]=example.com ENV["CERTIFICATE_CONTACT_ID"]=1 ruby ./request_letsencrypt_certificate.rb
+# Usage: ENV["CERTIFICATE_DOMAIN_ID"]=example.com ruby ./request_letsencrypt_certificate.rb
 
 require 'pp'
 require 'dnsimple'
@@ -8,8 +8,6 @@ require_relative 'token'
 
 ENV["CERTIFICATE_DOMAIN_ID"] or
     abort("set CERTIFICATE_DOMAIN_ID to the ID of the domain to request the certificate for")
-ENV["CERTIFICATE_CONTACT_ID"] or
-    abort("set CERTIFICATE_CONTACT_ID to the ID of the contact to use for the certificate")
 
 # Construct a client instance.
 #
@@ -30,7 +28,7 @@ response = client.identity.whoami
 account_id = response.data.account.id
 
 # Dnsimple::Client::Certificates#purchase_letsencrypt_certificate is the method to create a certificate order.
-response = client.certificates.purchase_letsencrypt_certificate(account_id, ENV["CERTIFICATE_DOMAIN_ID"], { contact_id: ENV["CERTIFICATE_CONTACT_ID"], name: ENV["CERTIFICATE_NAME"] || "www" })
+response = client.certificates.purchase_letsencrypt_certificate(account_id, ENV["CERTIFICATE_DOMAIN_ID"], { name: ENV["CERTIFICATE_NAME"] || "www" })
 
 # Pretty-print the entire response object so you can see what is inside.
 pp response

--- a/ruby/use_cases/issue_certificates/README.md
+++ b/ruby/use_cases/issue_certificates/README.md
@@ -30,7 +30,6 @@ This project is built on top of the [Sinatra](http://www.sinatrarb.com/) web fra
    cp .config.json.example .config.json
    ```
    Enter the information as per the template. Please note that only production works as the **sandbox** environment does not support issuance of certificates.
-   To obtain a `contact_id`, after you have entered the API token and account ID, you can open a pry shell `bundle exec pry` and run the following to get all contacts in the account `App::DnsimpleAdapter.list_all_contacts`
 
 5. Start your development server
    ```bash

--- a/ruby/use_cases/issue_certificates/lib/app/dnsimple.rb
+++ b/ruby/use_cases/issue_certificates/lib/app/dnsimple.rb
@@ -16,7 +16,6 @@ module App
     post '/issue_certificate' do
       certificate_order = App::DnsimpleAdapter.purchase_letsencrypt_certificate(
         parsed_request_body['domain'],
-        App.config.dnsimple['contact_id'],
         name: parsed_request_body['name'],
         alternate_names: parsed_request_body['san']&.split(','),
         auto_renew: parsed_request_body.fetch('auto_renew', true)

--- a/ruby/use_cases/issue_certificates/lib/app/dnsimple_adapter.rb
+++ b/ruby/use_cases/issue_certificates/lib/app/dnsimple_adapter.rb
@@ -84,9 +84,8 @@ module App
         client.certificates.certificate_private_key(config[:account_id], domain_id, certificate_id).data
       end
 
-      def purchase_letsencrypt_certificate(domain_id, contact_id, name: 'www', alternate_names: nil, auto_renew: false)
+      def purchase_letsencrypt_certificate(domain_id, name: 'www', alternate_names: nil, auto_renew: false)
         attributes = {
-          contact_id: contact_id,
           name: name,
           alternate_names: alternate_names,
           auto_renew: auto_renew

--- a/ruby/use_cases/issue_certificates/spec/.config.json
+++ b/ruby/use_cases/issue_certificates/spec/.config.json
@@ -2,7 +2,6 @@
   "dnsimple": {
     "api_token": "",
     "account_id": 1,
-    "contact_id": 1,
     "api_endpoint": "https://api.sandbox.dnsimple.com"
   }
 }


### PR DESCRIPTION
As `contact_id` no longer needed to purchase LE cert.

This changes will require for us to update the Ruby client version used, as it is indeed validating `contact_id` presence.

## Tasks
- [x] Update Ruby examples
- [x] Update Rust examples