### PR TITLE
Create Terraform DNS demo

### DIFF
--- a/terraform/dns/.gitignore
+++ b/terraform/dns/.gitignore
@@ -1,0 +1,3 @@
+.terraform.lock.hcl
+.terraform/
+terraform.tfstate*

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -1,0 +1,53 @@
+# DNSimple Terraform DNS Demo
+
+With the DNSimple Terraform Provider, you can manage your DNS infrastructure, including zones and records, directly within Terraform. This allows you to leverage the simplicity and power of Terraform's Infrastructure-as-Code design for your DNSimple resources, and coordinate them right alongside your other Terraform resources that form your infrastructure.
+
+To provide an example of the power, simplicity, and functionality of managing DNS using the DNSimple Terraform Provider, we've provided this demo that you can review, run, and play around with. We'll implement a basic email inbox service that has a simple but relatable design and structure of a full stack application with all the typical infrastructure:
+
+- An S3 bucket, acting as the data store, containing incoming emails collected via SES.
+- An [API service](./api.py), running on EC2 instances, distributed across two regions, that will serve the emails.
+- A simple [static web application](./app.html) that will be stored and served from an S3 bucket, which will present a UI for the data returned by the API.
+
+We'll showcase how, by using the DNSimple Terraform Provider, setting up the required DNS plumbing for this and almost all other services like it can enable smoother and more powerful planning, design, and operations of infrastructure:
+
+- DNS records are declared right alongside the components and resources they serve, so there's no loss of context or need for disjointed external tools or manual processes.
+- The Terraform resources can be committed to your VCS for centralising the source of truth, keeping declarations and state in sync, automated deployments, regression testing, policy enforcement, and inspecting the history of changes.
+- Leverage the full power of DNSimple's functionality and tools, like ALIAS and regional records, to empower your architecture.
+- Take advantage of all of Terraform's benefits with DNS records that are just like any other resource: drift detection, one-command deployment and synchronisation, clean and structured deletion, automatic dependency resolution, track and centralise state, and more.
+
+Feel free to use this proof-of-concept as the starting point for your next project, or as inspiration to swap parts out to build something completely different.
+
+## Prerequisites
+
+To run this demo, you will need:
+
+- An authoritative zone on DNSimple, where the DNS resolution is not delegated or disabled. If you purchased or transferred your domain to DNSimple, or you have pointed your domain's nameservers to DNSimple at your registrar, you should be good to go.
+  - If you'd like to registrar and set up a domain also entirely through Terraform, check out our [domains demo](../domains).
+- An API token for your DNSimple account must be generated and stored in your environment variables. See [here](https://support.dnsimple.com/articles/api-access-token/) for more details.
+- An AWS account. You must have AWS credentials on your machine ready to go. See [this guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) for more details.
+- Terraform must be installed. You can download it [here](https://developer.hashicorp.com/terraform/downloads).
+
+> [!WARNING]
+> DNS records will be overwritten on the zone, which may erase any current records and break services running on your domain.
+
+> [!NOTE]
+> This will create resources on your AWS account, which may incur charges. After running this demo, if you don't need it anymore, make sure to delete the resources.
+
+## Running
+
+This demo has been designed such that you only need to follow along the code in [main.tf](./main.tf). Each block has helpful, descriptive comments that are designed to be read like a guide sequentially, and build on top of previous code and comments.
+
+To get started, set up the Terraform project. Only one variable is required to run the demo, which is the domain that you wish to test with. Replace `mydomain.com` with your domain name.
+
+```bash
+terraform init
+export TF_VAR_domain=mydomain.com
+```
+
+Now, you can run the entire demo all at once, by running:
+
+```bash
+terraform apply
+```
+
+You can also run the demo incrementally, at your pace, by commenting out all code in [main.tf](./main.tf) after the point where you'd like to stop, and then running the above `terraform apply` command. Once you're happy to proceed, uncomment out some more code, and then repeat.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -51,3 +51,13 @@ terraform apply
 ```
 
 You can also run the demo incrementally, at your pace, by commenting out all code in [main.tf](./main.tf) after the point where you'd like to stop, and then running the above `terraform apply` command. Once you're happy to proceed, uncomment out some more code, and then repeat.
+
+## Cleaning up
+
+You can destroy all resources created by this demo by running:
+
+```bash
+terraform destroy
+```
+
+You may need to empty your emails S3 bucket first.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -1,19 +1,19 @@
 # DNSimple Terraform DNS Demo
 
-With the DNSimple Terraform Provider, you can manage your DNS infrastructure, including zones and records, directly within Terraform. This allows you to leverage the simplicity and power of Terraform's Infrastructure-as-Code design for your DNSimple resources, and coordinate them right alongside your other Terraform resources that form your infrastructure.
+With the DNSimple Terraform Provider, you can manage your DNS infrastructure, including zones and records, directly within Terraform. This lets you leverage the simplicity and power of Terraform's Infrastructure-as-Code design for your DNSimple resources, and coordinate them alongside the other Terraform resources that form your infrastructure.
 
-To provide an example of the power, simplicity, and functionality of managing DNS using the DNSimple Terraform Provider, we've provided this demo that you can review, run, and play around with. We'll implement a basic email inbox service that has a simple but relatable design and structure of a full stack application with all the typical infrastructure:
+As an example of the power, simplicity, and functionality of managing DNS using the DNSimple Terraform Provider, we've created this demo that you can review, run, and play around with. We'll implement a basic email inbox service with a simple but relatable design and structure of a full stack application with all the typical infrastructure:
 
 - An S3 bucket, acting as the data store, containing incoming emails collected via SES.
 - An [API service](./api.py), running on EC2 instances, distributed across two regions, that will serve the emails.
 - A simple [static web application](./app.html) that will be stored and served from an S3 bucket, which will present a UI for the data returned by the API.
 
-We'll showcase how, by using the DNSimple Terraform Provider, setting up the required DNS plumbing for this and almost all other services like it can enable smoother and more powerful planning, design, and operations of infrastructure:
+We'll showcase how, by using the DNSimple Terraform Provider, setting up the required DNS plumbing for this, and almost all other services like it, can enable smoother and more powerful planning, design, and operations of infrastructure:
 
-- DNS records are declared right alongside the components and resources they serve, so there's no loss of context or need for disjointed external tools or manual processes.
-- The Terraform resources can be committed to your VCS for centralising the source of truth, keeping declarations and state in sync, automated deployments, regression testing, policy enforcement, and inspecting the history of changes.
+- DNS records are declared alongside the components and resources they serve, so there's no loss of context or need for disjointed external tools or manual processes.
+- The Terraform resources can be committed to your VCS for centralizing the source of truth, keeping declarations and state in sync, automated deployments, regression testing, policy enforcement, and inspecting the history of changes.
 - Leverage the full power of DNSimple's functionality and tools, like ALIAS and regional records, to empower your architecture.
-- Take advantage of all of Terraform's benefits with DNS records that are just like any other resource: drift detection, one-command deployment and synchronisation, clean and structured deletion, automatic dependency resolution, track and centralise state, and more.
+- Take advantage of all of Terraform's benefits with DNS records that are just like any other resource: drift detection, one-command deployment and synchronization, clean and structured deletion, automatic dependency resolution, track and centralize state, and more.
 
 Feel free to use this proof-of-concept as the starting point for your next project, or as inspiration to swap parts out to build something completely different.
 
@@ -37,7 +37,7 @@ To run this demo, you will need:
 
 This demo has been designed such that you only need to follow along the code in [main.tf](./main.tf). Each block has helpful, descriptive comments that are designed to be read like a guide sequentially, and build on top of previous code and comments.
 
-To get started, set up the Terraform project. Only one variable is required to run the demo, which is the domain that you wish to test with. Replace `mydomain.com` with your domain name.
+To get started, set up the Terraform project. Only one variable is required to run the demo, which is the domain you want to test with. Replace `mydomain.com` with your domain name.
 
 ```bash
 terraform init
@@ -50,7 +50,7 @@ Now, you can run the entire demo all at once, by running:
 terraform apply
 ```
 
-You can also run the demo incrementally, at your pace, by commenting out all code in [main.tf](./main.tf) after the point where you'd like to stop, and then running the above `terraform apply` command. Once you're happy to proceed, uncomment out some more code, and then repeat.
+You can also run the demo incrementally, at your pace, by commenting out all code in [main.tf](./main.tf) after the point where you'd like to stop, and then running the above `terraform apply` command. Once you're ready to proceed, uncomment out some more code, and then repeat.
 
 ## Cleaning up
 

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -60,4 +60,4 @@ You can destroy all resources created by this demo by running:
 terraform destroy
 ```
 
-You may need to empty your emails S3 bucket first.
+You may need to empty your emails S3 bucket first. You can follow this [guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/empty-bucket.html) for more details.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -67,3 +67,11 @@ You may need to empty your emails S3 bucket first. You can follow this [guide](h
 As this is a demo, for simplicity reasons, there is no HTTPS set up for the API or the app. Use this demo for fun, not for private or sensitive information.
 
 An interesting exercise is to add HTTPS. You may find our [Terraform TLS Web Application demo](../tls-web-application) helpful in this regard.
+
+## See also
+
+- [DNSimple API](https://developer.dnsimple.com/v2/)
+- [DNSimple Terraform Provider support article](https://support.dnsimple.com/articles/terraform-provider/)
+- [DNSimple Terraform Provider reference](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs)
+- [DNSimple Terraform Provider announcement](https://blog.dnsimple.com/2021/12/introducing-dnsimple-terraform-provider/)
+- [DNSimple Supported DNS Record Types](https://support.dnsimple.com/articles/supported-dns-records/)

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -61,3 +61,9 @@ terraform destroy
 ```
 
 You may need to empty your emails S3 bucket first. You can follow this [guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/empty-bucket.html) for more details.
+
+## Notes
+
+As this is a demo, for simplicity reasons, there is no HTTPS set up for the API or the app. Use this demo for fun, not for private or sensitive information.
+
+An interesting exercise is to add HTTPS. You may find our [Terraform TLS Web Application demo](../tls-web-application) helpful in this regard.

--- a/terraform/dns/README.md
+++ b/terraform/dns/README.md
@@ -23,12 +23,12 @@ To run this demo, you will need:
 
 - An authoritative zone on DNSimple, where the DNS resolution is not delegated or disabled. If you purchased or transferred your domain to DNSimple, or you have pointed your domain's nameservers to DNSimple at your registrar, you should be good to go.
   - If you'd like to registrar and set up a domain also entirely through Terraform, check out our [domains demo](../domains).
-- An API token for your DNSimple account must be generated and stored in your environment variables. See [here](https://support.dnsimple.com/articles/api-access-token/) for more details.
+- An API token for your DNSimple account must be generated and stored as the `DNSIMPLE_TOKEN` environment variable. See [here](https://support.dnsimple.com/articles/api-access-token/) for more details. You'll also need to store your DNSimple account ID in the `DNSIMPLE_ACCOUNT` environment variable.
 - An AWS account. You must have AWS credentials on your machine ready to go. See [this guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) for more details.
 - Terraform must be installed. You can download it [here](https://developer.hashicorp.com/terraform/downloads).
 
 > [!WARNING]
-> DNS records will be overwritten on the zone, which may erase any current records and break services running on your domain.
+> It's best to use a fresh zone for testing, as we'll create common records at the root including ALIAS and MX, which will likely conflict with an existing in-use zone.
 
 > [!NOTE]
 > This will create resources on your AWS account, which may incur charges. After running this demo, if you don't need it anymore, make sure to delete the resources.
@@ -42,6 +42,8 @@ To get started, set up the Terraform project. Only one variable is required to r
 ```bash
 terraform init
 export TF_VAR_domain=mydomain.com
+export DNSIMPLE_TOKEN=abc
+export DNSIMPLE_ACCOUNT=1234
 ```
 
 Now, you can run the entire demo all at once, by running:
@@ -51,6 +53,8 @@ terraform apply
 ```
 
 You can also run the demo incrementally, at your pace, by commenting out all code in [main.tf](./main.tf) after the point where you'd like to stop, and then running the above `terraform apply` command. Once you're ready to proceed, uncomment out some more code, and then repeat.
+
+By the end of the demo, you will have set up a mail inbox service for your domain. You can test this out by sending an email to your domain, with any valid value for the [local part](https://datatracker.ietf.org/doc/html/rfc3696#section-3) e.g. `hello@mydomain.com`.
 
 ## Cleaning up
 

--- a/terraform/dns/api.py
+++ b/terraform/dns/api.py
@@ -1,0 +1,27 @@
+from flask import Flask
+from flask_cors import CORS
+import boto3
+
+s3 = boto3.client('s3')
+app = Flask("api")
+CORS(app)
+
+@app.route("/")
+def list_emails():
+    res = s3.list_objects_v2(
+        Bucket="${domain}-emails",
+    )
+    return {
+        "emails": [
+            {
+                "Id": o["Key"],
+                "Data": s3.get_object(
+                    Bucket="${domain}-emails",
+                    Key=o["Key"],
+                )["Body"].read().decode("utf-8")
+            }
+            for o in res["Contents"]
+        ]
+    }
+
+app.run(host="0.0.0.0", port=80)

--- a/terraform/dns/app.html
+++ b/terraform/dns/app.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DNSimple DNS Demo App</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    :root {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      font-size: 16px;
+      line-height: 1.5;
+    }
+
+    #emails {
+      border-collapse: collapse;
+      width: 100%;
+    }
+
+    #emails tbody tr {
+      cursor: pointer;
+    }
+
+    #emails tbody tr:hover {
+      background: #fafafa;
+    }
+
+    #emails th, #emails td {
+      border: 1px solid #eee;
+      padding: 0.5rem;
+    }
+
+    #emails th {
+      text-align: left;
+    }
+
+    #content {
+      margin-top: 1rem;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+  </style>
+</head>
+<body>
+  <h1>DNSimple DNS Demo App</h1>
+  <table id="emails">
+    <thead>
+      <tr>
+        <th>From</th>
+        <th>To</th>
+        <th>Date</th>
+        <th>Subject</th>
+      </tr>
+    </thead>
+    <tbody>
+      <template id="t-email">
+        <tr>
+          <td class="from"></td>
+          <td class="to"></td>
+          <td class="date"></td>
+          <td class="subject"></td>
+        </tr>
+      </template>
+    </tbody>
+  </table>
+  <article id="content">
+  </article>
+  <script>
+    (async () => {
+      const partition = (s, d) => {
+        const pos = s.indexOf(d);
+        return pos == -1 ? [s] : [s.slice(0, pos), s.slice(pos + d.length)];
+      };
+      const $ = s => document.querySelector(s);
+      const $emails = $("#emails tbody");
+      const $tEmail = $("#t-email");
+      const $content = $("#content");
+      const {emails} = await fetch(`http://api.${location.hostname}`).then(r => r.json());
+      const processRawEmail = (id, raw) => {
+        const [headersRaw, bodyRaw] = partition(raw, "\r\n\r\n");
+        const headers = Object.fromEntries(headersRaw.split("\r\n").map(l => partition(l, ": ")));
+        const contentType = headers["Content-Type"];
+        const $email = $tEmail.content.cloneNode(true).querySelector("tr");
+        $emails.append($email);
+        $email.addEventListener("click", e => {
+          if (!contentType?.includes("multipart/")) {
+            return $content.textContent = bodyRaw;
+          }
+          const boundary = /boundary="([^"]+)"/.exec(contentType)[1];
+          const formats = bodyRaw.split(`--${boundary}`).map(f => f.trim()).filter(f => f);
+          for (const f of formats) {
+            // The raw body ends with `--${boundary}--`.
+            if (f === "--") continue;
+            const [fHeadersRaw, fBodyRaw] = partition(f, "\r\n\r\n");
+            const fHeaders = Object.fromEntries(fHeadersRaw.split("\r\n").map(l => partition(l, ": ")));
+            if (!fHeaders["Content-Type"]?.includes("text/plain")) continue;
+            return $content.textContent = fBodyRaw;
+          }
+        }, true);
+        $email.querySelector(".from").textContent = headers["From"];
+        $email.querySelector(".to").textContent = headers["To"];
+        $email.querySelector(".date").textContent = headers["Date"];
+        $email.querySelector(".subject").textContent = headers["Subject"];
+      };
+      for (const { Id: id, Data: raw } of emails) {
+        try {
+          processRawEmail(id, raw);
+        } catch (err) {
+          console.warn("Failed to parse", id, "with error:", err);
+        }
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/terraform/dns/app.html
+++ b/terraform/dns/app.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DNSimple DNS Demo App</title>
+  <title>DNSimple Terraform Provider DNS Demo App</title>
   <style>
     * {
       box-sizing: border-box;
@@ -14,6 +14,22 @@
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       font-size: 16px;
       line-height: 1.5;
+    }
+
+    #app {
+      position: fixed;
+      inset: 0;
+      overflow: auto;
+      padding: 1rem;
+
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 1rem;
+    }
+
+    #logo {
+      margin: 0;
     }
 
     #emails {
@@ -39,36 +55,36 @@
     }
 
     #content {
-      margin-top: 1rem;
       white-space: pre-wrap;
       word-wrap: break-word;
     }
   </style>
 </head>
 <body>
-  <h1>DNSimple DNS Demo App</h1>
-  <table id="emails">
-    <thead>
-      <tr>
-        <th>From</th>
-        <th>To</th>
-        <th>Date</th>
-        <th>Subject</th>
-      </tr>
-    </thead>
-    <tbody>
-      <template id="t-email">
+  <div id="app">
+    <h1 id="logo">DNSimple Terraform Provider DNS Demo App</h1>
+    <table id="emails">
+      <thead>
         <tr>
-          <td class="from"></td>
-          <td class="to"></td>
-          <td class="date"></td>
-          <td class="subject"></td>
+          <th>From</th>
+          <th>To</th>
+          <th>Date</th>
+          <th>Subject</th>
         </tr>
-      </template>
-    </tbody>
-  </table>
-  <article id="content">
-  </article>
+      </thead>
+      <tbody>
+        <template id="t-email">
+          <tr>
+            <td class="from"></td>
+            <td class="to"></td>
+            <td class="date"></td>
+            <td class="subject"></td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+    <article id="content"></article>
+  </div>
   <script>
     (async () => {
       const partition = (s, d) => {

--- a/terraform/dns/cloud-init.sh
+++ b/terraform/dns/cloud-init.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -Eeuxo pipefail
+
+python3 -m ensurepip
+pip3 install boto3 Flask flask-cors
+python3 << 'EndOfPython'
+${code}
+EndOfPython

--- a/terraform/dns/iam/api-permissions.json
+++ b/terraform/dns/iam/api-permissions.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${domain}-emails/*",
+        "arn:aws:s3:::${domain}-emails"
+      ]
+    }
+  ]
+}

--- a/terraform/dns/iam/api-role-assume.json
+++ b/terraform/dns/iam/api-role-assume.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Sid": "",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      }
+    }
+  ]
+}

--- a/terraform/dns/iam/app-bucket-policy.json
+++ b/terraform/dns/iam/app-bucket-policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${domain}/*"
+      ]
+    }
+  ]
+}

--- a/terraform/dns/iam/emails-bucket-policy.json
+++ b/terraform/dns/iam/emails-bucket-policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSESPuts",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ses.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${domain}-emails/*"
+    }
+  ]
+}

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -81,9 +81,9 @@ resource "aws_ses_receipt_rule_set" "main" {
 
 // We only need one rule in our rule set: store incoming emails to our S3 bucket.
 resource "aws_ses_receipt_rule" "main" {
-  depends_on    = [aws_ses_active_receipt_rule_set.main, aws_s3_bucket_policy.emails]
+  depends_on    = [aws_s3_bucket_policy.emails]
   name          = "main"
-  rule_set_name = "main"
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
   enabled       = true
   s3_action {
     bucket_name = "${var.domain}-emails"
@@ -94,7 +94,7 @@ resource "aws_ses_receipt_rule" "main" {
 
 // Now that we have set up our rule set with all the rules we need, make the rule set active.
 resource "aws_ses_active_receipt_rule_set" "main" {
-  rule_set_name = "main"
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
 }
 
 // The last thing to do is to set up the MX record for our domain.

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -196,7 +196,7 @@ resource "dnsimple_zone_record" "api_virginia_record" {
 #   user_data = <<-EOT
 #     #!/bin/bash
 #     python3 -m ensurepip
-#     pip3 install boto3 Flask
+#     pip3 install boto3 Flask flask-cors
 #     python3 << 'EndOfPython'
 #     ${templatefile("api.py", { domain = var.domain })}
 #     EndOfPython
@@ -209,7 +209,7 @@ resource "dnsimple_zone_record" "api_virginia_record" {
 #   name      = "api"
 #   type      = "A"
 #   ttl       = 600
-#   value     = aws_instance.api-virginia.public_ip
+#   value     = aws_instance.api-sydney.public_ip
 #   regions   = ["SYD"]
 # }
 

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,0 +1,289 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.17.0"
+    }
+
+    dnsimple = {
+      source = "dnsimple/dnsimple"
+      version = "1.2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias = "aws-sydney"
+  region = "ap-southeast-2"
+}
+
+provider "dnsimple" {
+}
+
+variable "domain" {
+  type = string
+}
+
+// To demonstrate MX and TXT records and how you may use these with mail services, we'll set up AWS SES for our domain. First, we'll verify and set up our domain entirely within Terraform — no manual copy-and-pasting necessary. Then, we'll do some basic SES configuration to store incoming emails to our domain into an S3 bucket, so we can actually do something useful with this mail service setup.
+
+// Create our domain with SES. It won't be verified yet — we'll do that next.
+resource "aws_ses_domain_identity" "domain" {
+  domain = var.domain
+}
+
+// We need to verify our domain, so SES knows we are the true owners of the domain. This involves a simple TXT record, which we can set using the DNSimple zone record resource.
+resource "dnsimple_zone_record" "verification_record" {
+  zone_name = var.domain
+  name      = "_amazonses"
+  type      = "TXT"
+  ttl       = 600
+  value     = aws_ses_domain_identity.domain.verification_token
+}
+
+// Now that the record has been set, we'll ask SES to verify and domain and wait for its confirmation. This may take a few minutes...
+resource "aws_ses_domain_identity_verification" "domain" {
+  domain = aws_ses_domain_identity.domain.id
+  depends_on = [dnsimple_zone_record.verification_record]
+}
+
+// For this demo, we'll simply store all incoming emails in our S3 bucket, so lets create one now. SES can do more with incoming emails; see https://docs.aws.amazon.com/ses/latest/dg/receiving-email-concepts.html for more details.
+resource "aws_s3_bucket" "emails" {
+  bucket = "${var.domain}-emails"
+}
+
+// This sets the policy for the S3 bucket we've just created to allow SES to write to it. See more details at https://docs.aws.amazon.com/ses/latest/dg/receiving-email-permissions.html#receiving-email-permissions-s3.
+resource "aws_s3_bucket_policy" "emails" {
+  bucket = aws_s3_bucket.emails.id
+  policy = jsonencode({
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+        "Sid": "AllowSESPuts",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ses.amazonaws.com"
+        },
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::${var.domain}-emails/*",
+      }
+    ]
+  })
+}
+
+// A rule set tells SES what to do with incoming emails, with one or more rules. We'll create the only rule next, but first we need a rule set for the rule to be created into.
+resource "aws_ses_receipt_rule_set" "main" {
+  rule_set_name = "main"
+}
+
+// We only need one rule in our rule set: store incoming emails to our S3 bucket.
+resource "aws_ses_receipt_rule" "main" {
+  depends_on = [aws_ses_active_receipt_rule_set.main, aws_s3_bucket_policy.emails]
+  name          = "main"
+  rule_set_name = "main"
+  enabled       = true
+  s3_action {
+    bucket_name = "${var.domain}-emails"
+    // If you have more than one action, you can decide the order they're applied in by changing this attribute.
+    position    = 1
+  }
+}
+
+// Now that we have set up our rule set with all the rules we need, make the rule set active.
+resource "aws_ses_active_receipt_rule_set" "main" {
+  rule_set_name = "main"
+}
+
+// The last thing to do is to set up the MX record for our domain.
+// You can see that we've set up an entire mail inbox for our domain, including verification, completely within the same flow in the same Terraform script.
+resource "dnsimple_zone_record" "mx_record" {
+  zone_name = var.domain
+  name      = ""
+  type      = "MX"
+  ttl       = 600
+  priority  = 10
+  value     = "inbound-smtp.us-east-1.amazonaws.com"
+}
+
+// Now that we have some data (emails stored in our S3 bucket), we'll create an API to expose this information for our app (which we'll set up later). This is a common pattern for many projects and part of most infrastructure. We'll use EC2 instances to host our API server, and see how we can quickly set up the DNS plumbing to get our service up and running rapidly, right here in Terraform.
+
+// First, we need to create a role that will allow our instances to read the emails in our bucket.
+resource "aws_iam_role" "api" {
+  name = "api"
+
+  inline_policy {
+    name = "main"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid = ""
+          Action = [
+            "s3:GetObject",
+            "s3:ListBucket",
+          ]
+          Effect = "Allow"
+          Resource = [
+            "arn:aws:s3:::${var.domain}-emails/*",
+            "arn:aws:s3:::${var.domain}-emails",
+          ]
+        }
+      ]
+    })
+  }
+
+  // Allow our EC2 instances (which we'll create later) to assume this role.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+// We'll create an instance profile so that instances can assume the role we've just created. Learn more about them at https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html.
+resource "aws_iam_instance_profile" "api" {
+  name = "api"
+  role = aws_iam_role.api.name
+}
+
+// Now, we can create the instances and deploy our API service. We'll use a simple mechanism to deploy and run the service, which is to simply copy the Python code into our cloud-init script and run it immediately and indefinitely when our instance starts up. You can learn more about cloud-init at https://cloud-init.io/.
+// As our API server listens on port 80 (plaintext HTTP), ensure this server can be reached publicly over port 80, so adjust any VPC, subnet, and NSG attributes as necessary. WARNING: Because this is unencrypted, for the purposes of this demo, don't send any private or sensitive information via email to this domain!
+// Also, if you'd like to set up SSH access, make sure to provide `key_name`.
+resource "aws_instance" "api-virginia" {
+  // As of 2023-09-18, this is the AMI ID for Amazon Linux 2013 (x86) in us-east-1.
+  ami = "ami-04cb4ca688797756f"
+  associate_public_ip_address = true
+  instance_type = "t3a.micro"
+  iam_instance_profile = aws_iam_instance_profile.api.name
+  user_data = <<-EOT
+    #!/bin/bash
+    python3 -m ensurepip
+    pip3 install boto3 Flask flask-cors
+    python3 << 'EndOfPython'
+    ${templatefile("api.py", { domain = var.domain })}
+    EndOfPython
+  EOT
+}
+
+// Create the A record for our API server in Virginia.
+resource "dnsimple_zone_record" "api_virginia_record" {
+  zone_name = var.domain
+  name      = "api"
+  type      = "A"
+  ttl       = 600
+  value     = aws_instance.api-virginia.public_ip
+}
+
+// To demonstrate regional records, we'll spin up a replica API server in Sydney. It runs the same API server and will serve identical data, but will provide a lower latency experience for users in Australia.
+# resource "aws_instance" "api-sydney" {
+#   provider = aws.aws-sydney
+#   // As of 2023-09-18, this is the AMI ID for Amazon Linux 2013 (x86) in ap-southeast-2.
+#   ami = "ami-0dfb78957e4edea0c"
+#   associate_public_ip_address = true
+#   instance_type = "t3a.micro"
+#   iam_instance_profile = aws_iam_instance_profile.api.name
+#   user_data = <<-EOT
+#     #!/bin/bash
+#     python3 -m ensurepip
+#     pip3 install boto3 Flask
+#     python3 << 'EndOfPython'
+#     ${templatefile("api.py", { domain = var.domain })}
+#     EndOfPython
+#   EOT
+# }
+
+// Since all DNSimple DNS record types and features are supported using the Terraform Provider, we can trivially set up a regional record with ease. This provides a simple and flexible way to deploy multi-region infrastructure, whether it's multi-master, geo-replication, or something else, without leaving Terraform.
+# resource "dnsimple_zone_record" "api_sydney_record" {
+#   zone_name = var.domain
+#   name      = "api"
+#   type      = "A"
+#   ttl       = 600
+#   value     = aws_instance.api-virginia.public_ip
+#   regions   = ["SYD"]
+# }
+
+// Now that we have our API service up and running, it's time for the final part of our stack: the client. For simplicity, our client is a simple single-page HTML app with some light JavaScript, so we can use a single S3 bucket to serve the HTML over the Internet. Feel free to substitute this section with the client component in your system or architecture.
+
+// Create the bucket for hosting the app.
+resource "aws_s3_bucket" "app" {
+  bucket = var.domain
+}
+
+// Unblock public access, so anyone can reach our app.
+resource "aws_s3_bucket_public_access_block" "app" {
+  bucket = aws_s3_bucket.app.bucket
+  block_public_policy = false
+  restrict_public_buckets = false
+}
+
+// Set up the bucket policy so that anyone can reach our app.
+// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteAccessPermissionsReqd.html for more details.
+resource "aws_s3_bucket_policy" "app" {
+  // We must wait for `block_public_policy` to be disabled.
+  depends_on = [aws_s3_bucket_public_access_block.app]
+  bucket = aws_s3_bucket.app.bucket
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "PublicReadGetObject",
+        "Effect": "Allow",
+        "Principal": "*",
+        "Action": [
+          "s3:GetObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::${var.domain}/*"
+        ]
+      }
+    ]
+  })
+}
+
+// Configure the bucket to behave like a website. To learn more about this S3 feature, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html.
+resource "aws_s3_bucket_website_configuration" "app" {
+  bucket = aws_s3_bucket.app.bucket
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+// Upload our app to the bucket.
+resource "aws_s3_object" "object" {
+  bucket = aws_s3_bucket.app.bucket
+  key = "index.html"
+  source = "app.html"
+  content_type = "text/html"
+  etag = filemd5("app.html")
+}
+
+// We want users to be able to reach our app via our domain directly for user friendliness (e.g. myapp.com, not www.myapp.com or myapp.com.s3-website-us-east-1.amazonaws.com). However, S3 requires us to point our domain to an *.amazonaws.com domain in order to use the website feature, which means a CNAME record, but that's not allowed at the root by the DNS standard. Therefore, we can take advantage of a DNSimple feature called ALIAS records, which you can read more about at https://support.dnsimple.com/articles/alias-record. We can use these with the Terraform provider.
+resource "dnsimple_zone_record" "app" {
+  zone_name = var.domain
+  name      = ""
+  type      = "ALIAS"
+  ttl       = 600
+  value     = aws_s3_bucket_website_configuration.app.website_endpoint
+}
+
+// In case a user goes to `www.myapp.com`, we want them to redirect to `myapp.com` which is where our app is actually hosted. We don't need any additional resources or infrastructure to do this, we can simply take advantage of URL records, another DNSimple feature, right within Terraform.
+resource "dnsimple_zone_record" "app_www" {
+  zone_name = var.domain
+  name      = "www"
+  type      = "URL"
+  ttl       = 600
+  value     = "http://${var.domain}"
+}
+
+// Now we have completed the demo and set up all of our infrastructure! You can now try it out and play around. Try sending an email to your domain with any user (e.g. `hello@myapp.com`), and then visit your app. After a few seconds, the email should show up in the list.

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -7,7 +7,7 @@ terraform {
 
     dnsimple = {
       source  = "dnsimple/dnsimple"
-      version = "1.2.0"
+      version = "1.2.1"
     }
   }
 }
@@ -186,32 +186,32 @@ resource "dnsimple_zone_record" "api_virginia_record" {
 }
 
 // To demonstrate regional records, we'll spin up a replica API server in Sydney. It runs the same API server and will serve identical data, but will provide a lower latency experience for users in Australia.
-# resource "aws_instance" "api-sydney" {
-#   provider = aws.aws-sydney
-#   // As of 2023-09-18, this is the AMI ID for Amazon Linux 2013 (x86) in ap-southeast-2.
-#   ami = "ami-0dfb78957e4edea0c"
-#   associate_public_ip_address = true
-#   instance_type = "t3a.micro"
-#   iam_instance_profile = aws_iam_instance_profile.api.name
-#   user_data = <<-EOT
-#     #!/bin/bash
-#     python3 -m ensurepip
-#     pip3 install boto3 Flask flask-cors
-#     python3 << 'EndOfPython'
-#     ${templatefile("api.py", { domain = var.domain })}
-#     EndOfPython
-#   EOT
-# }
+resource "aws_instance" "api-sydney" {
+  provider = aws.aws-sydney
+  // As of 2023-09-18, this is the AMI ID for Amazon Linux 2013 (x86) in ap-southeast-2.
+  ami                         = "ami-0dfb78957e4edea0c"
+  associate_public_ip_address = true
+  instance_type               = "t3a.micro"
+  iam_instance_profile        = aws_iam_instance_profile.api.name
+  user_data                   = <<-EOT
+    #!/bin/bash
+    python3 -m ensurepip
+    pip3 install boto3 Flask flask-cors
+    python3 << 'EndOfPython'
+    ${templatefile("api.py", { domain = var.domain })}
+    EndOfPython
+  EOT
+}
 
 // Since all DNSimple DNS record types and features are supported using the Terraform Provider, we can trivially set up a regional record with ease. This provides a simple and flexible way to deploy multi-region infrastructure, whether it's multi-master, geo-replication, or something else, without leaving Terraform.
-# resource "dnsimple_zone_record" "api_sydney_record" {
-#   zone_name = var.domain
-#   name      = "api"
-#   type      = "A"
-#   ttl       = 600
-#   value     = aws_instance.api-sydney.public_ip
-#   regions   = ["SYD"]
-# }
+resource "dnsimple_zone_record" "api_sydney_record" {
+  zone_name = var.domain
+  name      = "api"
+  type      = "A"
+  ttl       = 600
+  value     = aws_instance.api-sydney.public_ip
+  regions   = ["SYD"]
+}
 
 // Now that we have our API service up and running, it's time for the final part of our stack: the client. For simplicity, our client is a simple single-page HTML app with some light JavaScript, so we can use a single S3 bucket to serve the HTML over the Internet. Feel free to substitute this section with the client component in your system or architecture.
 


### PR DESCRIPTION
This is a demo for showcasing the Terraform Provider and using it to manage DNS zone records.

Depends on https://github.com/dnsimple/terraform-provider-dnsimple/pull/156.
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/8 and https://github.com/dnsimple/dnsimple-marketing/issues/619.